### PR TITLE
Improve on logic for events

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -111,11 +111,12 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [b/BIRTHDAY] [g/GRO
 * Existing values will be updated to the input values.
 * When editing groups, the existing groups of the person will be removed i.e adding of groups is not cumulative.
 * You can remove all the person’s groups by typing `g/` without specifying any groups after it.
+* When you edit a person's name, the person's name will be updated in all [events](#commands-for-events) that the person is assigned to.
 
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
-*  `edit 2 n/Betsy Crower g/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing groups.
-*  `edit 3 n/Betsy Crower b/2023-09-29` Edits the name of the 3rd person to be `Betsy Crower` and changes the birthday to 29th Sep 2023.
+*  `edit 2 n/Betsy Crower g/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing groups. Any events that Betsy Crower is assigned to is also updated with this new name.
+*  `edit 3 n/Betsy Crower b/2023-09-29` Edits the name of the 3rd person to be `Betsy Crower` and changes the birthday to 29th Sep 2023. Any events that Betsy Crower is assigned to is also updated with this new name.
 
 Acceptable values for each parameter:
 * `INDEX`: A positive integer
@@ -162,7 +163,8 @@ Examples:
 
 ### Deleting a person : `delete`
 
-Deletes the specified person from the FumbleLog.
+Deletes the specified person from FumbleLog.
+When a person is deleted, any [events](#commands-for-events) that the person is assigned to will also be updated, i.e. the person will be unassigned from the event.
 
 Format: `delete INDEX`
 
@@ -172,7 +174,7 @@ Format: `delete INDEX`
 
 Examples:
 * `list` followed by `delete 2` deletes the 2nd person in the FumbleLog.
-* `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
+* `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command. i.e Any person named `Betsy` at index `1` will be deleted.
 
 Expected output when a command succeeds:
 * Input: `delete 1`
@@ -187,38 +189,46 @@ Expected output when the command fails:
 
 Add a meeting to the FumbleLog.
 
-Format: `add_meeting n/MEETING_DETAILS d/DATE [s/START_TIME] [e/END_TIME]`
+Format: `add_meeting m/MEETING_DETAILS d/DATE [s/START_TIME] [e/END_TIME] [n/NAME_OF_PERSON]...`
 
-- `START_TIME` and `END_TIME` are optional, however, **`START_TIME` must be coupled with `END_TIME`**.
+- `START_TIME` and `END_TIME` are optional.
+- `NAME_OF_PERSON` is optional and there can be multiple values supplied. Note that a person with a name matching `NAME_OF_PERSON` must exist in the FumbleLog.
+- The given `DATE`, `START_TIME` and `END_TIME` cannot be a time in the past.
+- The given `START_TIME` must be before the given `END_TIME`.
+- If the meeting is added successfully, it will automatically be sorted by date and time with the earliest meeting at the top of the list.
 
 Example: 
-* `add_meeting n/tP week 3 meeting d/2023-10-05 s/1500 e/1700`
+* `add_meeting m/tP week 3 meeting d/2023-10-05 s/1500 e/1700 n/John Doe n/Betsy Crower` - Adds a meeting named `tP week 3 meeting` on `5th Oct 2023` from `3pm` to `5pm` and assigns `John Doe` and `Betsy Crower` to the meeting. 
 
 Acceptable values for each parameter:
 * `n/MEETING_DETAILS`: Details of the meeting
 * `d/DATE`: A valid date in the format `yyyy-MM-dd`
 * `s/START_TIME`: A valid time in the format `HHmm` (Optional)
 * `e/END_TIME`: A valid time in the format `HHmm` (Optional)
+* `n/NAME_OF_PERSON`: Name of the person(s) to be assigned to the meeting (Optional)
 
 Expected output when the command succeeds:
-* Input: `add_meeting n/tP week 3 meeting d/2023-10-05 s/1500 e/1700`
+* Input: `add_meeting m/tP week 3 meeting d/2023-10-05 s/1500 e/1700`
 * Output: `New meeting added: tP week 3 meeting; Date: 2023-10-05; Start Time: 1500; End Time: 1700; `
 
 Expected output when the command fails:
-* `Invalid command format! add_meeting: Adds a meeting to the FumbleLog. Parameters: MEETING_DETAILS d/DATE [s/START_TIME] [e/END_TIME]`
+* `Invalid command format! add_meeting: Adds a meeting to the address book. Parameters: m/MEETING_NAME d/DATE [s/START_TIME][e/END_TIME][n/NAME]...`
+* `You cannot enter a time that is before the current time!` - When the given `DATE`, `START_TIME` and `END_TIME` is before the current time.
+* `You cannot enter an end time that is before the start time!` - When the given `START_TIME` is after the given `END_TIME`.
 
 ### Editing a meeting : `edit_meeting`
 
 Edits an existing meeting in the FumbleLog.
 
-Format: `edit_meeting INDEX [n/MEETING_DETAILS] [d/DATE] [s/START_TIME] [e/END_TIME]`
+Format: `edit_meeting INDEX [n/MEETING_DETAILS] [d/DATE] [s/START_TIME] [e/END_TIME] [n/PERSON_TO_ASSIGN]... [u/PERSON_TO_UNASSIGN]...`
 
 * **At least one of the optional parameters required.**
-* Existing values will be updated to the input values.
-* `START_TIME` must be coupled with `END_TIME`.
+* Existing values will be updated to the input values, except for the list of assigned persons, which will be appended to the existing list.
+* To unassign a person from the meeting, use the u/ prefix with the person's name(which must be a person previously assigned to the meeting).
+* If there are any changes to the meeting date and time, the meeting will be automatically sorted by date and time with the earliest meeting at the top of the list.
 
-Examples:
-*  `edit_meeting 1 n/tP week 4 meeting`
+* Examples:
+*  `edit_meeting 1 m/tP week 4 meeting`
 
 Acceptable values for each parameter:
 * `INDEX`: A positive integer
@@ -226,13 +236,19 @@ Acceptable values for each parameter:
 * `d/DATE`: A valid date in the format `yyyy-MM-dd` (Optional)
 * `s/START_TIME`: A valid time in the format `HHmm` (Optional)
 * `e/END_TIME`: A valid time in the format `HHmm` (Optional)
+* `n/PERSON_TO_ASSIGN`: Name of the person(s) to be assigned to the meeting (Optional)
+* `u/PERSON_TO_UNASSIGN`: Name of the person(s) to be unassigned from the meeting (Optional)
 
 Expected output when the command succeeds:
-* Input: `edit_meeting 1 n/tP week 3 meeting d/2023-10-05 s/1500 e/1700`
-* Output: `Meeting edited: tP week 3 meeting; Date: 2023-10-05; Start Time: 1500; End Time: 1700; `
+* Input: `edit_meeting 1 m/tP week 3 meeting d/2023-10-05 s/1500 e/1700 n/John Doe u/Mary` - Edits the meeting at index 1 to be named `tP week 3 meeting` on `5th Oct 2023` from `3pm` to `5pm`. Assigns `John Doe` to the meeting and unassigns `Mary` from the meeting.
+* Output: `Edited meeting: tP week 3 meeting; Date: 30 Oct 2023; Start Time: 15:00; End Time: 17:00; Persons involved: John Doe`
 
 Expected output when the command fails:
-* `Invalid command format! edit_meeting: Edits a meeting in the FumbleLog. Parameters: INDEX [MEETING_DETAILS] [d/DATE] [s/START_TIME] [e/END_TIME]`
+* `edit_meeting: Edits the details of the meeting identified by the index number used in the displayed meeting list.
+   Existing values will be overwritten by the input values, except for the list of assigned persons, which will be appended to the existing list.
+   Parameters: INDEX (must be a positive integer) [m/MEETING_DETAILS] [d/DATE] [s/START_TIME] [e/END_TIME] [n/NAME]... [u/NAME]...`
+* `You cannot enter a time that is before the current time!` - When the given `DATE`, `START_TIME` and `END_TIME` is before the current time.
+* `You cannot enter an end time that is before the start time!` - When the given `START_TIME` is after the given `END_TIME`.
 
 
 ### Deleting a meeting : `delete_meeting`
@@ -251,41 +267,11 @@ Acceptable values for each parameter:
 
 Expected output when the command succeeds:
 * Input: `delete_meeting 1`
-* Output: `Deleted Meeting: tP week 3 meeting; Date: 2023-10-05; Start Time: 1500; End Time: 1700; `
+* Output: `Deleted Meeting: tP week 3 meeting; Date: 2023-10-05; Start Time: 1500; End Time: 1700;`
 
 Expected output when the command fails:
 * `Invalid command format! delete_meeting: Deletes the meeting identified by the index number used in the displayed meeting list. Parameters: INDEX (must be a positive integer`
 
-## Commands between Events and Persons
-### Assign person to the meeting : `assign`
-
-Assigns a person to a meeting.
-
-Format: `assign MEETING_INDEX n/PERSON_NAME`
-
-* Assigns the person with the specified `PERSON_NAME` to the meeting at the specified `MEETING_INDEX`.
-
-Examples:
-* `assign 1 n/Bob` assigns the person named Bob to the meeting at index 1.
-
-Acceptable values for each parameter:
-* `MEETING_INDEX`: A positive integer
-* `n/MEETING_NAME`: Name of the person to be assigned
-
-### Unassign people from the meeting : `unassign`
-
-Unassigns a person from a meeting.
-
-Format: `unassign MEETING_INDEX n/PERSON_NAME`
-
-* Unassigns the person with the specified `PERSON_NAME` from the meeting at the specified `MEETING_INDEX`.
-
-Examples:
-* `unassign 1 n/Bob` unassigns the person named Bob from the meeting at index 1.
-
-Acceptable values for each parameter:
-* `PERSON_INDEX`: A positive integer
-* `n/MEETING_NAME`: Name of the person to be unassigned
 
 ## General commands
 
@@ -348,8 +334,8 @@ Action | Format, Examples
 ### Commands for Events
 Action | Format, Examples
 --------|------------------
-**Add Meeting** | `add_meeting n/MEETING_DETAILS d/DATE [s/START_TIME] [e/END_TIME]`<br> e.g., `add_meeting n/tP week 3 meeting d/2023-10-05 s/1500 e/1700`
-**Edit Meeting** | `edit_meeting INDEX [n/MEETING_DETAILS] [d/DATE] [s/START_TIME] [e/END_TIME]`<br> e.g., `edit_meeting 1 n/tP week 3 meeting`
+**Add Meeting** | `add_meeting m/MEETING_DETAILS d/DATE [s/START_TIME] [e/END_TIME] [n/PERSON_TO_ASSIGN]`<br> e.g., `add_meeting m/tP week 3 meeting d/2023-10-05 s/1500 e/1700 n/John Doe`
+**Edit Meeting** | `edit_meeting INDEX [m/MEETING_DETAILS] [d/DATE] [s/START_TIME] [e/END_TIME] [n/PERSON_TO_ASSIGN]... [u/PERSON_TO_UNASSIGN]`<br> e.g., `edit_meeting 1 m/tP week 3 meeting n/Mary u/John Doe`
 **Delete Meeting** | `delete_meeting INDEX`<br> e.g., `delete_meeting 1`
 
 ### Commands between Persons and Events

--- a/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
@@ -56,6 +56,8 @@ public class AddMeetingCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
+        CommandUtil.verifyEventTimes(this.toAdd);
+
         Set<Name> invalidNames = model.findInvalidNames(this.toAdd.getNames());
 
         if (!invalidNames.isEmpty()) {

--- a/src/main/java/seedu/address/logic/commands/CommandUtil.java
+++ b/src/main/java/seedu/address/logic/commands/CommandUtil.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.commands;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.event.Event;
+
+/**
+ * Represents utility tools used during command execution.
+ */
+public class CommandUtil {
+
+    /**
+     * Verifies that 1) Start time is not earlier than current time,
+     * 2) End Time is not earlier start time.
+     * @param event Event to be verified.
+     *
+     * @throws ParseException if the given {@code time} does not meet any of the above 2 criteria.
+     */
+    public static void verifyEventTimes(Event event) throws CommandException {
+
+        if (!event.hasStartTime() && !event.hasEndTime()) {
+            verifyTimeIsAfterCurrentTime(event.getStartDate().getDate().atTime(LocalTime.MAX));
+        } else if (!event.hasStartTime()) {
+            verifyTimeIsAfterCurrentTime(event.getEndDate().getDate()
+                    .atTime(event.getEndTime().getEventTime()));
+        } else if (!event.hasEndTime()) {
+            verifyTimeIsAfterCurrentTime(event.getStartDate().getDate()
+                    .atTime(event.getStartTime().getEventTime()));
+        } else {
+            verifyTimeIsAfterCurrentTime(event.getStartDate().getDate()
+                    .atTime(event.getStartTime().getEventTime()));
+
+            verifyEndTimeIsAfterStartTime(event);
+        }
+
+    }
+
+    private static void verifyEndTimeIsAfterStartTime(Event event) throws CommandException {
+        LocalDateTime combinedStartTime = event.getStartDate().getDate()
+                .atTime(event.getStartTime().getEventTime());
+
+        LocalDateTime combinedEndTime = event.getEndDate().getDate()
+                .atTime(event.getEndTime().getEventTime());
+
+        if (combinedEndTime.isBefore(combinedStartTime)) {
+            throw new CommandException(Event.END_TIME_CONSTRAINTS);
+        }
+    }
+
+    private static void verifyTimeIsAfterCurrentTime(LocalDateTime time) throws CommandException {
+        if (time.isBefore(LocalDateTime.now())) {
+            throw new CommandException(Event.START_TIME_CONSTRAINTS);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
@@ -86,8 +86,8 @@ public class EditMeetingCommand extends Command {
 
         //ensure that the user is not editing a valid time into an invalid time
         if (this.editMeetingDescriptor.getDate().isPresent()
-        || this.editMeetingDescriptor.getStartTime().isPresent()
-        || this.editMeetingDescriptor.getEndTime().isPresent()) {
+                || this.editMeetingDescriptor.getStartTime().isPresent()
+                || this.editMeetingDescriptor.getEndTime().isPresent()) {
             CommandUtil.verifyEventTimes(editedMeeting);
         }
 

--- a/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
@@ -83,6 +83,8 @@ public class EditMeetingCommand extends Command {
         Event meetingToEdit = lastShownList.get(index.getZeroBased());
         Event editedMeeting = createEditedMeeting(meetingToEdit, this.editMeetingDescriptor, model);
 
+        CommandUtil.verifyEventTimes(editedMeeting);
+
         model.setEvent(meetingToEdit, editedMeeting);
 
         return new CommandResult(generateSuccessMessage(editedMeeting));

--- a/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
@@ -52,6 +52,7 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
             meetingEndTime = ParserUtil.parseEventTime(argMultimap.getValue(PREFIX_END_TIME).get());
         }
 
+
         Meeting meeting = new Meeting(meetingName, eventDate,
                 Optional.of(meetingStartTime), Optional.of(meetingEndTime), nameList);
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -186,4 +186,6 @@ public class ParserUtil {
         String trimmedTime = time.trim();
         return EventTime.of(trimmedTime);
     }
+
+
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -127,6 +127,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void addEvent(Event event) {
         this.events.addEvent(event);
+        sort();
     }
 
     public void deleteEvent(Event event) {
@@ -170,5 +171,12 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public int hashCode() {
         return persons.hashCode();
+    }
+
+    /**
+     * Sorts the list of events.
+     */
+    public void sort() {
+        this.events.sort();
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -130,4 +130,6 @@ public interface Model {
      * @param personToDelete person to delete
      */
     void updateAssignedPersons(Person personToDelete);
+
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -127,6 +127,7 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedEvent);
 
         this.addressBook.setEvent(target, editedEvent);
+        sort();
     }
 
     @Override
@@ -167,7 +168,11 @@ public class ModelManager implements Model {
     @Override
     public void addEvent(Event toAdd) {
         addressBook.addEvent(toAdd);
+        sort();
+    }
 
+    private void sort() {
+        this.addressBook.sort();
     }
 
     @Override
@@ -225,6 +230,8 @@ public class ModelManager implements Model {
         return false;
     }
 
+
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -241,4 +248,5 @@ public class ModelManager implements Model {
                 && this.userPrefs.equals(otherModelManager.userPrefs)
                 && this.filteredPersons.equals(otherModelManager.filteredPersons);
     }
+
 }

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -3,6 +3,8 @@ package seedu.address.model.event;
 
 import static seedu.address.model.event.EventTime.NULL_EVENT_TIME;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -13,6 +15,9 @@ import seedu.address.model.person.Name;
  * Represents an Event in the address book.
  */
 public abstract class Event {
+
+    public static final String START_TIME_CONSTRAINTS = "You cannot enter a time that is before the current time!";
+    public static final String END_TIME_CONSTRAINTS = "You cannot enter an end time that is before the start time!";
 
     private Set<Name> names;
     private EventDate startDate;
@@ -121,5 +126,35 @@ public abstract class Event {
         }
         return newNames;
 
+    }
+
+    /**
+     * Returns true if the event is overdue.
+     */
+    public boolean isOverDue() {
+        if (!hasStartTime() && !hasEndTime()) {
+            if (LocalDateTime.now().isBefore(this.getStartDate().getDate().atTime(LocalTime.MAX))) {
+                return false;
+            }
+            return true;
+        } else if (!hasStartTime()) {
+            if (LocalDateTime.now().isBefore(this.getEndDate().getDate()
+                    .atTime(this.getEndTime().getEventTime()))) {
+                return false;
+            }
+            return true;
+        } else if (!hasEndTime()) {
+            if (LocalDateTime.now().isBefore(this.getStartDate().getDate()
+                    .atTime(this.getStartTime().getEventTime()))) {
+                return false;
+            }
+            return true;
+        } else {
+            if (LocalDateTime.now().isBefore(this.getStartDate().getDate()
+                    .atTime(this.getStartTime().getEventTime()))) {
+                return false;
+            }
+            return true;
+        }
     }
 }

--- a/src/main/java/seedu/address/model/event/EventComparator.java
+++ b/src/main/java/seedu/address/model/event/EventComparator.java
@@ -14,15 +14,44 @@ public class EventComparator implements Comparator<Event> {
      */
     public int compare(Event event1, Event event2) {
         if (event1.getStartDate().getDate().isBefore(event2.getStartDate().getDate())) {
-            return 1;
+            return -1;
         } else if (event1.getStartDate().getDate().isAfter(event2.getStartDate().getDate())) {
-            return -1;
-        } else if (event1.getStartTime().getEventTime().isBefore(event2.getStartTime().getEventTime())) {
             return 1;
-        } else if (event1.getStartTime().getEventTime().isAfter(event2.getStartTime().getEventTime())) {
-            return -1;
-        } else {
-            return 0;
         }
+
+        //compare the startTime if it is present
+        if (event1.hasStartTime() && event2.hasStartTime()) {
+            if (event1.getStartTime().getEventTime().isBefore(event2.getStartTime().getEventTime())) {
+                return -1;
+            } else if (event1.getStartTime().getEventTime().isAfter(event2.getStartTime().getEventTime())) {
+                return 1;
+            }
+        }
+
+        //if one of the event has startTime, it will be placed before the other
+        if (event1.hasStartTime() && !event2.hasStartTime()) {
+            return -1;
+        } else if (event2.hasStartTime() && !event1.hasStartTime()) {
+            return 1;
+        }
+
+        if (event1.hasEndTime() && event2.hasEndTime()) {
+            if (event1.getEndTime().getEventTime().isBefore(event2.getEndTime().getEventTime())) {
+                return -1;
+            } else if (event1.getEndTime().getEventTime().isAfter(event2.getEndTime().getEventTime())) {
+                return 1;
+            }
+        }
+
+        //if one of the event has endTime, it will be placed before the other
+
+        if (event1.hasEndTime() && !event2.hasEndTime()) {
+            return -1;
+        } else if (event2.hasEndTime() && !event1.hasEndTime()) {
+            return 1;
+        }
+
+        return 0;
+
     }
 }

--- a/src/main/java/seedu/address/model/event/EventList.java
+++ b/src/main/java/seedu/address/model/event/EventList.java
@@ -69,4 +69,11 @@ public class EventList {
             throw new EventNotFoundException();
         }
     }
+
+    /**
+     * Sorts the list of events.
+     */
+    public void sort() {
+        this.internalList.sort(new EventComparator());
+    }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -163,7 +163,7 @@ public class Person {
      * Returns true if the person has a birthday.
      */
     public boolean hasBirthday() {
-        return getBirthday() != Birthday.NULL_BIRTHDAY && getBirthday() != null;
+        return getBirthday() != Birthday.NULL_BIRTHDAY && getBirthday() != null && !getBirthday().equals("");
     }
     /**
      * Returns true if the person has groups.

--- a/src/main/java/seedu/address/ui/EventListPanel.java
+++ b/src/main/java/seedu/address/ui/EventListPanel.java
@@ -46,7 +46,7 @@ public class EventListPanel extends UiPart<Region> {
                 setText(null);
             } else {
                 if (event.isOverDue()) {
-                    setGraphic(new ExpiredEventCard(personList, event,getIndex() + 1).getRoot());
+                    setGraphic(new ExpiredEventCard(personList, event, getIndex() + 1).getRoot());
                 } else {
                     setGraphic(new EventCard(personList, event, getIndex() + 1).getRoot());
                 }

--- a/src/main/java/seedu/address/ui/EventListPanel.java
+++ b/src/main/java/seedu/address/ui/EventListPanel.java
@@ -41,7 +41,11 @@ public class EventListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new EventCard(event, getIndex() + 1).getRoot());
+                if (event.isOverDue()) {
+                    setGraphic(new ExpiredEventCard(event, getIndex() + 1).getRoot());
+                } else {
+                    setGraphic(new EventCard(event, getIndex() + 1).getRoot());
+                }
             }
         }
     }

--- a/src/main/java/seedu/address/ui/ExpiredEventCard.java
+++ b/src/main/java/seedu/address/ui/ExpiredEventCard.java
@@ -10,19 +10,11 @@ import javafx.scene.layout.Region;
 import seedu.address.model.event.Event;
 
 /**
- * An UI component that displays information of an {@code Event}.
+ * UI component that displays information of an expired event.
  */
-public class EventCard extends UiPart<Region> {
+public class ExpiredEventCard extends UiPart<Region> {
 
-    private static final String FXML = "EventListCard.fxml";
-
-    /**
-     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
-     * As a consequence, UI elements' variable names cannot be set to such keywords
-     * or an exception will be thrown by JavaFX during runtime.
-     *
-     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
-     */
+    private static final String FXML = "ExpiredEventCard.fxml";
 
     public final Event event;
 
@@ -40,15 +32,16 @@ public class EventCard extends UiPart<Region> {
     private FlowPane names;
 
     /**
-     * Creates an {@code EventCode} with the given {@code Event} and index to display.
+     * Creates a {@code ExpiredEventCard} with the given {@code Event} and index to display.
+     * @param event
+     * @param displayedIndex
      */
-    public EventCard(Event event, int displayedIndex) {
+    public ExpiredEventCard(Event event, int displayedIndex) {
         super(FXML);
         this.event = event;
         id.setText(displayedIndex + ". ");
         name.setText(event.getName().name);
         date.setText(event.getStartDate().forDisplay());
-
 
         if (event.hasStartTime() && event.hasEndTime()) {
             timeDuration.setText(String.format("%s - %s",
@@ -68,4 +61,6 @@ public class EventCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(name -> name.fullName))
                 .forEach(name -> names.getChildren().add(new Label(name.fullName)));
     }
+
+
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -107,8 +107,9 @@
     -fx-background-color: #515658;
 }
 
+
 .list-cell:filled:selected {
-    -fx-background-color: #424d5f;
+    /*-fx-background-color: #424d5f;*/
 }
 
 .list-cell:filled:selected #cardPane {
@@ -358,7 +359,7 @@
 
 #names .label {
     -fx-text-fill: white;
-    -fx-background-color: #3e7b91;
+    -fx-background-color: #008000;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
     -fx-background-radius: 2;

--- a/src/main/resources/view/ExpiredEventCard.fxml
+++ b/src/main/resources/view/ExpiredEventCard.fxml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<HBox id="cardPane" fx:id="cardPane" style="-fx-background-color: #fc3542; -fx-blend-mode: lighten; -fx-border-width: 1;" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+        </columnConstraints>
+        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+            <padding>
+                <Insets bottom="5" left="15" right="5" top="5" />
+            </padding>
+            <HBox alignment="CENTER_LEFT" spacing="5">
+                <Label fx:id="id" styleClass="cell_big_label">
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE" />
+                    </minWidth>
+                </Label>
+                <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
+            </HBox>
+            <Label fx:id="date" styleClass="cell_small_label" text="\$date" />
+            <Label fx:id="timeDuration" styleClass="cell_small_label" text="\$timeDuration" />
+            <FlowPane fx:id="names" />
+        </VBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
+    </GridPane>
+   <opaqueInsets>
+      <Insets />
+   </opaqueInsets>
+</HBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.net.URL?>
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.Scene?>
-<?import javafx.scene.control.Menu?>
-<?import javafx.scene.control.MenuBar?>
-<?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.image.Image?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.StackPane?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.stage.Stage?>
+<?import java.net.*?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.image.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.stage.*?>
 
-<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="Address App" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="Address App" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -33,7 +29,7 @@
           </Menu>
         </MenuBar>
 
-        <StackPane fx:id="commandBoxPlaceholder" styleClass="pane-with-border" VBox.vgrow="NEVER">
+        <StackPane fx:id="commandBoxPlaceholder" prefWidth="553.0" styleClass="pane-with-border" VBox.vgrow="NEVER">
           <padding>
             <Insets bottom="5" left="10" right="10" top="5" />
           </padding>

--- a/src/test/java/seedu/address/model/event/EventComparatorTest.java
+++ b/src/test/java/seedu/address/model/event/EventComparatorTest.java
@@ -11,8 +11,8 @@ public class EventComparatorTest {
     @Test
     public void compareTest() {
         EventComparator eventComparator = new EventComparator();
-        assertEquals(1, eventComparator.compare(TP_MEETING, MEETING_LATER_THAN_TP_MEETING));
+        assertEquals(-1, eventComparator.compare(TP_MEETING, MEETING_LATER_THAN_TP_MEETING));
         assertEquals(0, eventComparator.compare(TP_MEETING, TP_MEETING));
-        assertEquals(-1, eventComparator.compare(MEETING_LATER_THAN_TP_MEETING, TP_MEETING));
+        assertEquals(1, eventComparator.compare(MEETING_LATER_THAN_TP_MEETING, TP_MEETING));
     }
 }


### PR DESCRIPTION
Add the following safeguards:

1) Users can no longer input meeting time that has expired

2) Users can no longer input meeting end times that are later than the start times

Improve on UI to display expired events by highlighting them in red

Adding/editing meetings now automatically sorts them by time